### PR TITLE
Modify type for Condition in IAMPolicyStatement

### DIFF
--- a/policy/aide.go
+++ b/policy/aide.go
@@ -27,7 +27,7 @@ type IAMPolicyStatement struct {
 	Effect    string
 	Action    StrOrSlice
 	Resource  StrOrSlice
-	Condition StrOrSlice `json:",omitempty"`
+	Condition map[string]interface{} `json:",omitempty"`
 }
 
 // StrOrSlice is a helper for objects that could be strings or slices.


### PR DESCRIPTION
Modify type from `StrOrSlice` to accept a `map[string]interface{}` since Condition is expressed in that manner. https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements_condition.html