### PR TITLE
YAML support for IAM policies

### DIFF
--- a/policy/aide.go
+++ b/policy/aide.go
@@ -17,18 +17,18 @@ import (
 
 // IAMPolicy is an AWS IAM policy document used for converting to and from json.
 type IAMPolicy struct {
-	Version   string
-	Statement []IAMPolicyStatement
+	Version   string               `yaml:"Version"`
+	Statement []IAMPolicyStatement `yaml:"Statement"`
 }
 
 // IAMPolicyStatement is a statement object within an AWS IAM policy.
 type IAMPolicyStatement struct {
-	ID        string `json:"Sid"`
-	Effect    string
-	Action    StrOrSlice
-	Resource  StrOrSlice             `json:",omitempty"`
-	Principal map[string]interface{} `json:",omitempty"`
-	Condition map[string]interface{} `json:",omitempty"`
+	ID        string                 `json:"Sid" yaml:"Sid"`
+	Effect    string                 `yaml:"Effect"`
+	Action    StrOrSlice             `yaml:"Action"`
+	Resource  StrOrSlice             `json:",omitempty" yaml:"Resource,omitempty"`
+	Principal map[string]interface{} `json:",omitempty" yaml:"Principal,omitempty"`
+	Condition map[string]interface{} `json:",omitempty" yaml:"Condition,omitempty"`
 }
 
 // StrOrSlice is a helper for objects that could be strings or slices.

--- a/policy/aide_test.go
+++ b/policy/aide_test.go
@@ -74,7 +74,7 @@ func TestUnmarshalJSON_errSliceUnmarshal(t *testing.T) {
 		SS1 StrOrSlice
 	}{}
 	j := []byte(`{"SS0": "test", "SS1": {"noobjects": ["test", "slice"]}}`)
-	want := "json: cannot unmarshal object into Go value of type []string"
+	want := "json: cannot unmarshal object into Go struct field .SS1 of type []string"
 	if err := json.Unmarshal(j, &res); err == nil {
 		t.Errorf("expected error; want: %s", err)
 	} else {

--- a/policy/aide_test.go
+++ b/policy/aide_test.go
@@ -83,3 +83,48 @@ func TestUnmarshalJSON_errSliceUnmarshal(t *testing.T) {
 		}
 	}
 }
+
+func TestIAMPolicyJSON(t *testing.T) {
+	policy := IAMPolicy{
+		Version: "12",
+	}
+	out, err := json.Marshal(policy)
+	if err != nil {
+		t.Errorf("unexpected error; got: %s", err)
+	}
+	want := "{\"Version\":\"12\",\"Statement\":null}"
+	if string(out) != want {
+		t.Errorf("unexpected out; want: %s got %s", want, string(out))
+	}
+}
+
+func TestIAMPolicyStatementEmptyJSON(t *testing.T) {
+	policy := IAMPolicyStatement{
+		ID: "12",
+	}
+	out, err := json.Marshal(policy)
+	if err != nil {
+		t.Errorf("unexpected error; got: %s", err)
+	}
+	want := "{\"Sid\":\"12\",\"Effect\":\"\",\"Action\":null}"
+	if string(out) != want {
+		t.Errorf("unexpected out; want: %s got %s", want, string(out))
+	}
+}
+
+func TestIAMPolicyStatementNotEmptyJSON(t *testing.T) {
+	policy := IAMPolicyStatement{
+		ID:        "12",
+		Resource:  StrOrSlice{"iam:"},
+		Principal: map[string]interface{}{"AWS": "iam"},
+		Condition: map[string]interface{}{"String": "matching ARN"},
+	}
+	out, err := json.Marshal(policy)
+	if err != nil {
+		t.Errorf("unexpected error; got: %s", err)
+	}
+	want := `{"Sid":"12","Effect":"","Action":null,"Resource":["iam:"],"Principal":{"AWS":"iam"},"Condition":{"String":"matching ARN"}}`
+	if string(out) != want {
+		t.Errorf("unexpected out; want: %s got %s", want, string(out))
+	}
+}

--- a/policy/aide_yaml.go
+++ b/policy/aide_yaml.go
@@ -1,0 +1,42 @@
+package policy
+
+// CloudFormation templates are often in YAML, so we have a YAML serializer/deserializer.
+
+import (
+	"github.com/go-yaml/yaml"
+	"strings"
+)
+
+// MarshalYAML is a method on custom type StringOrSlice that satisfies the
+// interface provided by the yaml package.
+// If the length of the given item is only one, we marshal the string. If
+// greater than one, we marshal the slice as an array.
+func (ss StrOrSlice) MarshalYAML() (interface{}, error) {
+	if len(ss) == 1 {
+		out, err := yaml.Marshal(([]string)(ss)[0])
+		if err != nil {
+			return nil, err
+		}
+		return strings.TrimSpace(string(out)), nil
+	}
+	return ss, nil
+}
+
+// UnmarshalYAML is a method on custom type StringOrSlice that satisfies the
+// interface provided by the yaml package.
+// If the object in data is of length one we unmarshal into a slice, converting
+// the array of one string. If the length is greater than one, we simply
+// unmarshal into our slice.
+func (ss *StrOrSlice) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	var s string
+	if err := unmarshal(&s); err != nil {
+		var v []string
+		if err := unmarshal(&v); err != nil {
+			return err
+		}
+		*ss = v
+		return nil
+	}
+	*ss = []string{s}
+	return nil
+}

--- a/policy/aide_yaml_test.go
+++ b/policy/aide_yaml_test.go
@@ -1,0 +1,68 @@
+package policy
+
+import (
+	"github.com/go-yaml/yaml"
+	"testing"
+)
+
+func TestMarshalYAML(t *testing.T) {
+	res := &struct {
+		SS0 StrOrSlice
+		SS1 StrOrSlice
+	}{
+		SS0: StrOrSlice([]string{"test"}),
+		SS1: StrOrSlice([]string{"test", "slice"}),
+	}
+	b, err := yaml.Marshal(res)
+	if err != nil {
+		t.Error(err)
+	}
+	want := `ss0: test
+ss1:
+- test
+- slice
+`
+
+	if string(b) != want {
+		t.Errorf("incorrectly marshaled; want: %s, got: %s", want, string(b))
+	}
+}
+
+func TestUnmarshalYAML(t *testing.T) {
+
+	type MyType struct {
+		Empty   StrOrSlice `yaml:"empty"`
+		Str     StrOrSlice `yaml:"str"`
+		List    StrOrSlice `yaml:"list"`
+		Errored StrOrSlice
+	}
+
+	input := `
+empty:
+str: "foo"
+list:
+  - bar
+  - baz
+errored:
+  foo: bar
+`
+	output := &MyType{}
+	want := "yaml: unmarshal errors:\n  line 8: cannot unmarshal !!map into []string"
+	if err := yaml.Unmarshal([]byte(input), output); err == nil {
+		t.Errorf("expected error; want: %s", err)
+	} else {
+		if err.Error() != want {
+			t.Errorf("unexpected error; want: %s, got: %s", want, err)
+		}
+	}
+
+	if output.Empty != nil {
+		t.Error("Empty was not empty")
+	}
+	if output.Str[0] != "foo" {
+		t.Errorf("Str wanted %s got %s", "foo", output.Str[0])
+	}
+	if output.List[1] != "baz" {
+		t.Errorf("List wanted %s got %s", "baz", output.List[1])
+	}
+}


### PR DESCRIPTION
Problem: CloudFormation Templates (CFT) are often in YAML and can contain IAM-style policy documents. aidews has structs that can serialize and deserialize to JSON, but not YAML.

This pull request does the following:

* Marshal and Unmarshal StrOrSlice to YAML 
* Tag the structs so YAML can be de-serialized 
* Fix error expectation for JSON unmarshalling (there was a test error)

Please advise if pull requests should be submitted in a different way. Thanks!