### PR TITLE
Query and Scan dynamo using pagers, return each item

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,11 +4,11 @@ aidews
 aidews is a helper (aide) for AWS. [aws-sdk-go](https://github.com/aws/aws-sdk-go) is fantastic, but this simplifies some of its uses.
 
 ## Session
-Session is the backbone helper of aidews and makes getting an [aws-sdk-go] session straight-forward
+Session is the backbone helper of aidews and makes getting an aws-sdk-go session straight-forward
 
 The `region` and `role_arn` parameters are optional. If neither are given the
 session returned is built with a blank config. If region is given, the config
-used to get the session includes the region. If role_arn given, we first STS,
+used to get the session includes the region. If `role_arn` given, we first STS,
 then get a session in that region using the credentials from the STS call.
 All Sessions are constructed using the SharedConfigEnable setting allowing
 the use of local credential resolution.
@@ -33,7 +33,7 @@ sess := aidews.Session(nil, &role)
 ```
 
 ## apigateway
-adiews apigateway package provides helpers for making signed requests to api gateways
+aidews apigateway package provides helpers for making signed requests to api gateways
 
 ``` go
 // Create client
@@ -72,3 +72,46 @@ If your favorite HTTP verb is not present in our helpers, you may use the Do fun
 req, _ := http.NewRequest("DELETE", "we/all/fall/down", nil)
 resp, err := client.Do(req)
 ```
+
+## dynamodb
+
+Package dynamodb provides a DynamoDB wrapper object.
+
+QueryPages queries the table and unmarshals each page of results to provided function.
+Caller should provide an item of some type that will be populated and each item will be
+returned to the provided pager function.
+Provided pager function should take a single interface{} and assert the type of the item (e.g. Item),
+and a boolean which will indicate whether this is the last item.
+Provided pager function should return false if it wants to stop processing.
+Example:
+
+```go
+items := Item
+pager := func(out interface{}, last bool) bool {
+  if out.(Item).Found { return false }
+  return !last
+}
+if err := QueryPages(queryInput, item, pager); err != nil {
+ return err
+}
+```
+
+ScanPages scans the table and unmarshals each page of results to provided function.
+Caller should provide an item of some type that will be populated and each item will be
+returned to the provided pager function.
+Provided pager function should take a single interface{} and assert the type of the item (e.g. Item),
+and a boolean which will indicate whether this is the last item.
+Provided pager function should return false if it wants to stop processing.
+Example:
+
+```go
+items := Item
+pager := func(out interface{}, last bool) bool {
+  if out.(Item).Found { return false }
+  return !last
+}
+if err := ScanPages(queryInput, item, pager); err != nil {
+ return err
+}
+```
+

--- a/dynamodb/aide.go
+++ b/dynamodb/aide.go
@@ -59,6 +59,41 @@ func (svc *Service) Query(in *dynamodb.QueryInput, out interface{}) error {
 	return dynamodbattribute.UnmarshalListOfMaps(items, out)
 }
 
+// QueryPages queries the table and unmarshals each page of results to provided function.
+// Caller should provide an item of some type that will be populated and each item will be
+// returned to the provided pager function.
+// Provided pager function should take a single interface{} and assert the type of the item (e.g. Item),
+// and a boolean which will indicate whether this is the last item.
+// Provided pager function should return false if it wants to stop processing.
+// Example:
+// items := Item
+// pager := func(out interface{}, last bool) bool {
+//   if out.(Item).Found { return false }
+//   return !last
+// }
+// if err := QueryPages(queryInput, item, pager); err != nil {
+//	return err
+// }
+func (svc *Service) QueryPages(in *dynamodb.QueryInput, outItem interface{}, outPager func(interface{}, bool) bool) error {
+	var marshallErr error
+	pager := func(pageOut *dynamodb.QueryOutput, last bool) bool {
+		for _, item := range pageOut.Items {
+			marshallErr = dynamodbattribute.UnmarshalMap(item, outItem)
+			if marshallErr != nil {
+				return false
+			}
+			if !outPager(outItem, last) {
+				return false
+			}
+		}
+		return !last
+	}
+	if err := svc.svc.QueryPages(in, pager); err != nil {
+		return err
+	}
+	return marshallErr
+}
+
 // Scan the table and return all results.
 func (svc *Service) Scan(in *dynamodb.ScanInput, out interface{}) error {
 	items := []map[string]*dynamodb.AttributeValue{}

--- a/dynamodb/aide.go
+++ b/dynamodb/aide.go
@@ -106,3 +106,38 @@ func (svc *Service) Scan(in *dynamodb.ScanInput, out interface{}) error {
 	}
 	return dynamodbattribute.UnmarshalListOfMaps(items, out)
 }
+
+// ScanPages scans the table and unmarshals each page of results to provided function.
+// Caller should provide an item of some type that will be populated and each item will be
+// returned to the provided pager function.
+// Provided pager function should take a single interface{} and assert the type of the item (e.g. Item),
+// and a boolean which will indicate whether this is the last item.
+// Provided pager function should return false if it wants to stop processing.
+// Example:
+// items := Item
+// pager := func(out interface{}, last bool) bool {
+//   if out.(Item).Found { return false }
+//   return !last
+// }
+// if err := ScanPages(queryInput, item, pager); err != nil {
+//	return err
+// }
+func (svc *Service) ScanPages(in *dynamodb.ScanInput, outItem interface{}, outPager func(interface{}, bool) bool) error {
+	var marshallErr error
+	pager := func(pageOut *dynamodb.ScanOutput, last bool) bool {
+		for _, item := range pageOut.Items {
+			marshallErr = dynamodbattribute.UnmarshalMap(item, outItem)
+			if marshallErr != nil {
+				return false
+			}
+			if !outPager(outItem, last) {
+				return false
+			}
+		}
+		return !last
+	}
+	if err := svc.svc.ScanPages(in, pager); err != nil {
+		return err
+	}
+	return marshallErr
+}

--- a/dynamodb/aide_test.go
+++ b/dynamodb/aide_test.go
@@ -72,3 +72,48 @@ func TestQueryPages(t *testing.T) {
 		t.Errorf(`titles: wanted: {%s}, got: {%s}`, wantedTitles, titles)
 	}
 }
+
+func TestScanPages(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	ddbMock := mock_dynamodbiface.NewMockDynamoDBAPI(ctrl)
+
+	ddbMock.EXPECT().ScanPages(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(input *dynamodb.ScanInput, f func(*dynamodb.ScanOutput, bool) bool) error {
+			if *input.TableName != pagesTable {
+				t.Errorf(`table: want: "%s", got: "%s"`, pagesTable, *input.TableName)
+			}
+			pagerReturn := f(&dynamodb.ScanOutput{Items: pagesOutput1}, false)
+			if pagerReturn != false {
+				t.Error("did not return false when pager returned false")
+			}
+			f(&dynamodb.ScanOutput{Items: pagesOutput2}, true)
+			return nil
+		},
+	)
+
+	slugs := []string{}
+	titles := []string{}
+	pager := func(item interface{}, lastPage bool) bool {
+		fmt.Printf("item: %#v\n", item)
+		slugs = append(slugs, item.(*row).Slug)
+		titles = append(titles, item.(*row).Title)
+		return false
+	}
+
+	input := &dynamodb.ScanInput{TableName: &pagesTable}
+	svc := Service{svc: ddbMock}
+	if err := svc.ScanPages(input, &row{}, pager); err != nil {
+		t.Error(err)
+	}
+
+	wantedSlugs := []string{"xkcd", "wasd"}
+	if !reflect.DeepEqual(slugs, wantedSlugs) {
+		t.Errorf(`slugs: wanted: {%s}, got: {%s}`, wantedSlugs, slugs)
+	}
+	wantedTitles := []string{"Some guy", "gaming"}
+	if !reflect.DeepEqual(slugs, wantedSlugs) {
+		t.Errorf(`titles: wanted: {%s}, got: {%s}`, wantedTitles, titles)
+	}
+}

--- a/dynamodb/aide_test.go
+++ b/dynamodb/aide_test.go
@@ -1,0 +1,74 @@
+package dynamodb
+
+import (
+	"fmt"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/dynamodb"
+	"github.com/cleardataeng/aidews/dynamodb/extmocks/github.com/aws/aws-sdk-go/service/dynamodb"
+	"github.com/golang/mock/gomock"
+	"reflect"
+	"testing"
+)
+
+//go:generate mockgen -destination=extmocks/github.com/aws/aws-sdk-go/service/dynamodb/mock.go github.com/aws/aws-sdk-go/service/dynamodb/dynamodbiface DynamoDBAPI
+
+type row struct {
+	Slug  string
+	Title string
+}
+
+var pagesOutput1 = []map[string]*dynamodb.AttributeValue{
+	map[string]*dynamodb.AttributeValue{"slug": {S: aws.String("xkcd")}, "title": {S: aws.String("Some guy")}},
+	map[string]*dynamodb.AttributeValue{"slug": {S: aws.String("hijk")}, "title": {S: aws.String("vim")}},
+}
+
+var pagesOutput2 = []map[string]*dynamodb.AttributeValue{
+	map[string]*dynamodb.AttributeValue{"slug": {S: aws.String("wasd")}, "title": {S: aws.String("gaming")}},
+}
+
+var pagesTable = "movement_keys"
+
+func TestQueryPages(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	ddbMock := mock_dynamodbiface.NewMockDynamoDBAPI(ctrl)
+
+	ddbMock.EXPECT().QueryPages(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(input *dynamodb.QueryInput, f func(*dynamodb.QueryOutput, bool) bool) error {
+			if *input.TableName != pagesTable {
+				t.Errorf(`table: want: "%s", got: "%s"`, pagesTable, *input.TableName)
+			}
+			pagerReturn := f(&dynamodb.QueryOutput{Items: pagesOutput1}, false)
+			if pagerReturn != false {
+				t.Error("did not return false when pager returned false")
+			}
+			f(&dynamodb.QueryOutput{Items: pagesOutput2}, true)
+			return nil
+		},
+	)
+
+	slugs := []string{}
+	titles := []string{}
+	pager := func(item interface{}, lastPage bool) bool {
+		fmt.Printf("item: %#v\n", item)
+		slugs = append(slugs, item.(*row).Slug)
+		titles = append(titles, item.(*row).Title)
+		return false
+	}
+
+	input := &dynamodb.QueryInput{TableName: &pagesTable}
+	svc := Service{svc: ddbMock}
+	if err := svc.QueryPages(input, &row{}, pager); err != nil {
+		t.Error(err)
+	}
+
+	wantedSlugs := []string{"xkcd", "wasd"}
+	if !reflect.DeepEqual(slugs, wantedSlugs) {
+		t.Errorf(`slugs: wanted: {%s}, got: {%s}`, wantedSlugs, slugs)
+	}
+	wantedTitles := []string{"Some guy", "gaming"}
+	if !reflect.DeepEqual(slugs, wantedSlugs) {
+		t.Errorf(`titles: wanted: {%s}, got: {%s}`, wantedTitles, titles)
+	}
+}

--- a/dynamodb/dynamodbiface/interface.go
+++ b/dynamodb/dynamodbiface/interface.go
@@ -9,4 +9,5 @@ type Service interface {
 	Query(*dynamodb.QueryInput, interface{}) error
 	QueryPages(in *dynamodb.QueryInput, outItems []interface{}, outPager func(interface{}, bool) bool) error
 	Scan(*dynamodb.ScanInput, interface{}) error
+	ScanPages(in *dynamodb.ScanInput, outItems []interface{}, outPager func(interface{}, bool) bool) error
 }

--- a/dynamodb/dynamodbiface/interface.go
+++ b/dynamodb/dynamodbiface/interface.go
@@ -7,5 +7,6 @@ type Service interface {
 	GetItem(*dynamodb.GetItemInput, interface{}) error
 	PutItem(*dynamodb.PutItemInput, interface{}) (*dynamodb.PutItemOutput, error)
 	Query(*dynamodb.QueryInput, interface{}) error
+	QueryPages(in *dynamodb.QueryInput, outItems []interface{}, outPager func(interface{}, bool) bool) error
 	Scan(*dynamodb.ScanInput, interface{}) error
 }


### PR DESCRIPTION
We have Scan and Query functions in aidews that use the AWS pager API. However these functions unmarshal all the data into memory and then return a slice. If the returned items are several pages, we could be unmarshalling hundreds of items into memory.

These new functions instead un-marshal each item and yield it to the pager function. Essentially, these functions insert an un-marshal step into AWS's usual paged query/scan workflow.

Why not change the existing functions? Because that would require a change to the function signatures, breaking any existing code.