### PR TITLE
Add NewWithSession to apigateway aide.

### DIFF
--- a/apigateway/aide.go
+++ b/apigateway/aide.go
@@ -9,6 +9,7 @@ import (
 	"net/url"
 	"time"
 
+	"github.com/aws/aws-sdk-go/aws/session"
 	v4 "github.com/aws/aws-sdk-go/aws/signer/v4"
 	"github.com/cleardataeng/aidews"
 )
@@ -35,14 +36,15 @@ func New(host *url.URL, region string, roleARN *string) *Service {
 // NewWithHeaders returns an API with which you can make API Gateway signed requests with headers.
 func NewWithHeaders(host *url.URL, region string, roleARN *string, headers map[string]string) *Service {
 	s := aidews.Session(&region, roleARN)
+// NewWithSession returns an API like New but with a given Session.
+func NewWithSession(host *url.URL, session *session.Session) *Service {
 	return &Service{
-		signer: v4.NewSigner(s.Config.Credentials),
+		signer: v4.NewSigner(session.Config.Credentials),
 		host:   host,
-		region: s.Config.Region,
+		region: session.Config.Region,
 		http: &http.Client{
 			Timeout: time.Second * 60,
 		},
-		headers: headers,
 	}
 }
 

--- a/apigateway/aide.go
+++ b/apigateway/aide.go
@@ -30,7 +30,8 @@ type Service struct {
 
 // New returns an API with which you can make API Gateway signed requests.
 func New(host *url.URL, region string, roleARN *string) *Service {
-	return NewWithHeaders(host, region, roleARN, nil)
+	s := aidews.Session(&region, roleARN)
+	return NewWithSession(host, s)
 }
 
 // NewWithHeaders returns an API with which you can make API Gateway signed requests with headers.

--- a/apigateway/aide.go
+++ b/apigateway/aide.go
@@ -36,7 +36,11 @@ func New(host *url.URL, region string, roleARN *string) *Service {
 
 // NewWithHeaders returns an API with which you can make API Gateway signed requests with headers.
 func NewWithHeaders(host *url.URL, region string, roleARN *string, headers map[string]string) *Service {
-	s := aidews.Session(&region, roleARN)
+	svc := New(host, region, roleARN)
+	svc.SetHeaders(headers)
+	return svc
+}
+
 // NewWithSession returns an API like New but with a given Session.
 func NewWithSession(host *url.URL, session *session.Session) *Service {
 	return &Service{
@@ -102,6 +106,11 @@ func (svc *Service) Put(path string, body interface{}) (*http.Response, error) {
 	}
 	req, _ := http.NewRequest("PUT", u.String(), seeker)
 	return svc.Do(req)
+}
+
+// SetHeaders for the API service.
+func (svc *Service) SetHeaders(headers map[string]string) {
+	svc.headers = headers
 }
 
 // URL adds a valid path to the Gateway host and adds an encoded query string.

--- a/apigateway/apigatewayiface/interface.go
+++ b/apigateway/apigatewayiface/interface.go
@@ -11,4 +11,5 @@ type Service interface {
 	Get(string, url.Values) (*http.Response, error)
 	Put(string, interface{}) (*http.Response, error)
 	Post(string, interface{}) (*http.Response, error)
+	SetHeaders(map[string]string)
 }


### PR DESCRIPTION
This allows the creation of an API Gateway aide with a prebuilt session.Session, rather that requiring you to generate the service from a given roleARN. The motivation was allow the use of session hop to get to an api invocation role via another account / role.