### PR TITLE
Add WithContext methods to dynamodb aide

### DIFF
--- a/dynamodb/aide_test.go
+++ b/dynamodb/aide_test.go
@@ -1,13 +1,15 @@
 package dynamodb
 
 import (
+	"context"
 	"fmt"
+	"reflect"
+	"testing"
+
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/dynamodb"
 	"github.com/cleardataeng/aidews/dynamodb/extmocks/github.com/aws/aws-sdk-go/service/dynamodb"
 	"github.com/golang/mock/gomock"
-	"reflect"
-	"testing"
 )
 
 //go:generate mockgen -destination=extmocks/github.com/aws/aws-sdk-go/service/dynamodb/mock.go github.com/aws/aws-sdk-go/service/dynamodb/dynamodbiface DynamoDBAPI
@@ -17,25 +19,28 @@ type row struct {
 	Title string
 }
 
-var pagesOutput1 = []map[string]*dynamodb.AttributeValue{
-	map[string]*dynamodb.AttributeValue{"slug": {S: aws.String("xkcd")}, "title": {S: aws.String("Some guy")}},
-	map[string]*dynamodb.AttributeValue{"slug": {S: aws.String("hijk")}, "title": {S: aws.String("vim")}},
-}
+var (
+	ctx = context.Background()
 
-var pagesOutput2 = []map[string]*dynamodb.AttributeValue{
-	map[string]*dynamodb.AttributeValue{"slug": {S: aws.String("wasd")}, "title": {S: aws.String("gaming")}},
-}
+	pagesOutput1 = []map[string]*dynamodb.AttributeValue{
+		map[string]*dynamodb.AttributeValue{"slug": {S: aws.String("xkcd")}, "title": {S: aws.String("Some guy")}},
+		map[string]*dynamodb.AttributeValue{"slug": {S: aws.String("hijk")}, "title": {S: aws.String("vim")}},
+	}
+	pagesOutput2 = []map[string]*dynamodb.AttributeValue{
+		map[string]*dynamodb.AttributeValue{"slug": {S: aws.String("wasd")}, "title": {S: aws.String("gaming")}},
+	}
 
-var pagesTable = "movement_keys"
+	pagesTable = "movement_keys"
+)
 
-func TestQueryPages(t *testing.T) {
+func TestService_QueryPagesWithContext(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
 	ddbMock := mock_dynamodbiface.NewMockDynamoDBAPI(ctrl)
 
-	ddbMock.EXPECT().QueryPages(gomock.Any(), gomock.Any()).DoAndReturn(
-		func(input *dynamodb.QueryInput, f func(*dynamodb.QueryOutput, bool) bool) error {
+	ddbMock.EXPECT().QueryPagesWithContext(ctx, gomock.Any(), gomock.Any()).DoAndReturn(
+		func(_ context.Context, input *dynamodb.QueryInput, f func(*dynamodb.QueryOutput, bool) bool) error {
 			if *input.TableName != pagesTable {
 				t.Errorf(`table: want: "%s", got: "%s"`, pagesTable, *input.TableName)
 			}
@@ -59,7 +64,7 @@ func TestQueryPages(t *testing.T) {
 
 	input := &dynamodb.QueryInput{TableName: &pagesTable}
 	svc := Service{svc: ddbMock}
-	if err := svc.QueryPages(input, &row{}, pager); err != nil {
+	if err := svc.QueryPagesWithContext(ctx, input, &row{}, pager); err != nil {
 		t.Error(err)
 	}
 
@@ -73,14 +78,14 @@ func TestQueryPages(t *testing.T) {
 	}
 }
 
-func TestScanPages(t *testing.T) {
+func TestService_ScanPagesWithContext(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
 	ddbMock := mock_dynamodbiface.NewMockDynamoDBAPI(ctrl)
 
-	ddbMock.EXPECT().ScanPages(gomock.Any(), gomock.Any()).DoAndReturn(
-		func(input *dynamodb.ScanInput, f func(*dynamodb.ScanOutput, bool) bool) error {
+	ddbMock.EXPECT().ScanPagesWithContext(ctx, gomock.Any(), gomock.Any()).DoAndReturn(
+		func(_ context.Context, input *dynamodb.ScanInput, f func(*dynamodb.ScanOutput, bool) bool) error {
 			if *input.TableName != pagesTable {
 				t.Errorf(`table: want: "%s", got: "%s"`, pagesTable, *input.TableName)
 			}
@@ -104,7 +109,7 @@ func TestScanPages(t *testing.T) {
 
 	input := &dynamodb.ScanInput{TableName: &pagesTable}
 	svc := Service{svc: ddbMock}
-	if err := svc.ScanPages(input, &row{}, pager); err != nil {
+	if err := svc.ScanPagesWithContext(ctx, input, &row{}, pager); err != nil {
 		t.Error(err)
 	}
 

--- a/dynamodb/dynamodbiface/interface.go
+++ b/dynamodb/dynamodbiface/interface.go
@@ -1,13 +1,26 @@
 package dynamodbiface
 
-import "github.com/aws/aws-sdk-go/service/dynamodb"
+import (
+	"context"
+
+	"github.com/aws/aws-sdk-go/service/dynamodb"
+	aide "github.com/cleardataeng/aidews/dynamodb"
+)
 
 // Service provides access to data in DynamoDB.
 type Service interface {
 	GetItem(*dynamodb.GetItemInput, interface{}) error
+	GetItemWithContext(context.Context, *dynamodb.GetItemInput, interface{}) error
 	PutItem(*dynamodb.PutItemInput, interface{}) (*dynamodb.PutItemOutput, error)
+	PutItemWithContext(context.Context, *dynamodb.PutItemInput, interface{}) (*dynamodb.PutItemOutput, error)
 	Query(*dynamodb.QueryInput, interface{}) error
+	QueryWithContext(context.Context, *dynamodb.QueryInput, interface{}) error
 	QueryPages(in *dynamodb.QueryInput, outItems interface{}, outPager func(interface{}, bool) bool) error
+	QueryPagesWithContext(ctx context.Context, in *dynamodb.QueryInput, outItems interface{}, outPager func(interface{}, bool) bool) error
 	Scan(*dynamodb.ScanInput, interface{}) error
+	ScanWithContext(context.Context, *dynamodb.ScanInput, interface{}) error
 	ScanPages(in *dynamodb.ScanInput, outItems interface{}, outPager func(interface{}, bool) bool) error
+	ScanPagesWithContext(ctx context.Context, in *dynamodb.ScanInput, outItems interface{}, outPager func(interface{}, bool) bool) error
 }
+
+var _ Service = (*aide.Service)(nil) // test that the aide satisfies the interface


### PR DESCRIPTION
We'd like to send context with our dynamo calls. This PR adds `...WithContext` equivalents to all the dynamo aide methods. The original methods are still there, but now they call the new methods with a `context.TODO()`.